### PR TITLE
Test frame selector column security

### DIFF
--- a/cairo_programs/cairo0/conditional.cairo
+++ b/cairo_programs/cairo0/conditional.cairo
@@ -1,0 +1,13 @@
+func conditional(x) -> felt {
+    if (x == 5) {
+        return x + 1;
+    } else {
+        return x * 2;
+    }
+}
+
+func main() {
+    let x = 5;
+    let y = conditional(x);
+    return ();
+}


### PR DESCRIPTION
Implements #78.
This PR adds two tests and a program that has the following form:
```
let x = 5;
if x == 5 {
  // Do something...
} else {
  // Do something else...
}
```

The added tests modify the program and the memory values of the trace so that
`let x = 5;`
is now
`let x = 10;`

This would make the modified program behave different to the original one.
The added tests verify the execution of the program, with a difference between them:
- The first test sets the entire frame selector column to all zeros.
- The second test leaves the frame selector column unchanged.

This causes the first test to *accept* the execution proof and the second test to *reject* the execution proof.
So, by setting the frame selector column to zero, we can modify the program and the memory values of the trace and the verifier would accept the corresponding execution proof.